### PR TITLE
build: make `build_standalone.sh` useable for git-bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,21 @@
+# Intellij IDEA project files
+.idea/
+
+# Python bytecode and virtual environment
 .venv/
 __pycache__/
 *.pyc
 .pytest_cache/
+
+# Streamlit specific files
 .streamlit/
+
+# macOS system files
 .DS_Store
+
+# distribution files
 dist/
 build/
-building_data.json
+
+# application files
+building_data_Demo.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ dist/
 build/
 
 # application files
-building_data_Demo.json
+!building_data_Demo.json
+building_data*.json

--- a/build_standalone.sh
+++ b/build_standalone.sh
@@ -7,10 +7,10 @@ echo ""
 # Prüfen ob Virtual Environment aktiv ist
 if [ -z "$VIRTUAL_ENV" ]; then
     echo "⚠️  Aktiviere Virtual Environment..."
-    if [ -f ".venv/bin/activate" ]; then
-        source .venv/bin/activate
-    elif [ -f "venv/bin/activate" ]; then
-        source venv/bin/activate
+    activate_script=$(find .venv -type f -name "activate" | head -n 1)
+
+    if [ -n "$activate_script" ]; then
+        source "$activate_script"
     else
         echo "❌ Kein Virtual Environment gefunden!"
         echo "   Bitte erstellen: python -m venv .venv"
@@ -61,7 +61,7 @@ if [ -f "dist/din12831-heatload" ]; then
     echo ""
     echo "🚀 Starten mit: ./dist/din12831-heatload"
     echo ""
-    
+
     # Dateigrößen anzeigen
     SIZE=$(du -h dist/din12831-heatload | cut -f1)
     echo "📊 Größe: $SIZE"


### PR DESCRIPTION
- calculate the path to the `activate` script dynamically. The path depends on the environment.
- do not check-in IntelliJ files

git-bash: .venv/Scripts/activate